### PR TITLE
[task] update syntax

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,5 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 
-export default function AuthLayout({ children }: PropsWithChildren) {
+export default function AuthLayout({ children }: React.PropsWithChildren) {
   return <div>{children}</div>;
 }

--- a/app/(auth)/sign-in/page.tsx
+++ b/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import { useRouter } from 'next/navigation';
 
 import ROUTES from '@/constants/ROUTES';

--- a/app/(default)/layout.tsx
+++ b/app/(default)/layout.tsx
@@ -1,9 +1,9 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 
 import { SiteFooter } from '@/components/site-footer';
 import { SiteHeader } from '@/components/site-header';
 
-export default function RootLayout({ children }: PropsWithChildren) {
+export default function RootLayout({ children }: React.PropsWithChildren) {
   return (
     <div className="flex flex-1 flex-col">
       <SiteHeader />

--- a/app/(default)/reviewing/[...slug]/_components/review-card.tsx
+++ b/app/(default)/reviewing/[...slug]/_components/review-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import dynamic from 'next/dynamic';
 
 import Icon from '@/components/common/icon';
@@ -16,17 +16,11 @@ import {
 
 import { cn } from '@/lib/utils';
 import { OpenAIMessage } from '@/services';
+import { useGPTMessageDialog } from '@/zustand/useModal';
 
 const Message = dynamic(() => import('@/components/common/message'), {
   loading: () => <MessageSkeleton />,
 });
-
-const ChatWithGPTDialog = dynamic(
-  () => import('@/components/dialog/chat-with-gpt-dialog'),
-  {
-    loading: () => <Skeleton className="h-9 w-[158px] rounded-md" />,
-  },
-);
 
 const gradeColor = (gradeValue: string | -1) => {
   const colorMap = {
@@ -75,6 +69,8 @@ export default function ReviewCard({
   isLoadingReview,
   onUserSendMessage,
 }: ReviewCardProps) {
+  const { setIsOpen } = useGPTMessageDialog();
+
   const [open, setOpen] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(false);
 
@@ -167,13 +163,10 @@ export default function ReviewCard({
             type="button"
             onClick={(e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
               e.stopPropagation();
+              setIsOpen(true);
             }}
           >
-            <ChatWithGPTDialog
-              content={content}
-              isLoading={isLoading || isLoadingReview}
-              onSubmitMessage={handleUserSendMessage}
-            />
+            Chat with GPT
           </button>
         </div>
       </div>

--- a/app/(default)/reviewing/[...slug]/_components/review-header.tsx
+++ b/app/(default)/reviewing/[...slug]/_components/review-header.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import AppInput from '@/components/common/app-input';
 import Icon from '@/components/common/icon';

--- a/app/(default)/reviewing/[...slug]/layout.tsx
+++ b/app/(default)/reviewing/[...slug]/layout.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { useRouter } from 'next/navigation';
 
 import ROUTES from '@/constants/ROUTES';
 import { useAuthContext } from '@/context/auth';
 
-export default function ReviewLayout({ children }: PropsWithChildren) {
+export default function ReviewLayout({ children }: React.PropsWithChildren) {
   const { push } = useRouter();
   const { isLogin } = useAuthContext();
 

--- a/app/(default)/reviewing/[...slug]/page.tsx
+++ b/app/(default)/reviewing/[...slug]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import debounce from 'lodash.debounce';
 import { RefreshCw } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 
 import Icon from '@/components/common/icon';
+import ChatWithGPTDialog from '@/components/dialog/chat-with-gpt-dialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -14,6 +15,7 @@ import { getContentFileRepository, getReviewFromChatGPT } from '@/services/chatG
 import { ReviewMessageMap, ReviewMessageRole } from '@/types/chatGPT';
 import getReviewPrompt from '@/utils/prompt';
 import { GitHubFileType, useGetGithubRepositoryOverview, useGetRepositoryFiles } from '@/zustand/useGetGithubRepository';
+import { useGPTMessageDialog } from '@/zustand/useModal';
 
 import ReviewCard from './_components/review-card';
 import ReviewHeader from './_components/review-header';
@@ -28,6 +30,7 @@ interface Props {
 
 export default function DynamicPage(props: Props) {
   const { params } = props;
+  const { isOpen } = useGPTMessageDialog();
 
   const router = useRouter();
 
@@ -181,47 +184,52 @@ export default function DynamicPage(props: Props) {
   if (!overview) return null;
 
   return (
-    <section className="container mt-10">
-      <Card>
-        <CardContent className="px-4 py-6">
-          <ReviewHeader repositoryOverView={overview} onSearchFiles={handleSearchFiles} />
+    <>
+      <section className="container mt-10">
+        <Card>
+          <CardContent className="px-4 py-6">
+            <ReviewHeader repositoryOverView={overview} onSearchFiles={handleSearchFiles} />
 
-          <div className="mt-4">
-            <Card>
-              <CardContent className="flex flex-col gap-y-2 p-4">
-                {filteredFiles.map((file: GitHubFileType) => (
-                  <ReviewCard
-                    key={file.sha}
-                    fileName={file.path}
-                    content={reviewMessages?.[file.path] ?? []}
-                    isLoadingReview={isLoadingReview}
-                    onUserSendMessage={handleUserSendMessage}
-                  />
-                ))}
-              </CardContent>
-            </Card>
+            <div className="mt-4">
+              <Card>
+                <CardContent className="flex flex-col gap-y-2 p-4">
+                  {filteredFiles.map((file: GitHubFileType) => (
+                    <ReviewCard
+                      key={file.sha}
+                      fileName={file.path}
+                      content={reviewMessages?.[file.path] ?? []}
+                      isLoadingReview={isLoadingReview}
+                      onUserSendMessage={handleUserSendMessage}
+                    />
+                  ))}
+                </CardContent>
+              </Card>
 
-            <div className="mt-4 flex items-center justify-between">
-              {page > 1 ? (
-                <Button variant="ghost" onClick={handlePrevPage}>
-                  <Icon name="move-left" className="mr-2 h-4 w-4 text-gray-500" />
-                  Previous page
-                </Button>
-              ) : <div />}
+              <div className="mt-4 flex items-center justify-between">
+                {page > 1 ? (
+                  <Button variant="ghost" onClick={handlePrevPage}>
+                    <Icon name="move-left" className="mr-2 h-4 w-4 text-gray-500" />
+                    Previous page
+                  </Button>
+                ) : <div />}
 
-              {page < Math.ceil(files.length / 10) && (
-                <Button variant="ghost" onClick={handleNextPage}>
-                  Next page
-                  <Icon
-                    name="move-right"
-                    className="ml-2 h-4 w-4 text-gray-500"
-                  />
-                </Button>
-              )}
+                {page < Math.ceil(files.length / 10) && (
+                  <Button variant="ghost" onClick={handleNextPage}>
+                    Next page
+                    <Icon
+                      name="move-right"
+                      className="ml-2 h-4 w-4 text-gray-500"
+                    />
+                  </Button>
+                )}
+              </div>
             </div>
-          </div>
-        </CardContent>
-      </Card>
-    </section>
+          </CardContent>
+        </Card>
+      </section>
+
+      {isOpen
+      && <ChatWithGPTDialog content={[]} isLoading onSubmitMessage={() => {}} />}
+    </>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { Metadata } from 'next';
 
 import ProgressBarProvider from '@/components/progress-bar';
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: PropsWithChildren) {
+export default function RootLayout({ children }: React.PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning>
       <head />

--- a/components/common/app-input.tsx
+++ b/components/common/app-input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import dynamicIconImports from 'lucide-react/dynamicIconImports';
 
 import { cn } from '@/lib/utils';

--- a/components/common/app-textarea.tsx
+++ b/components/common/app-textarea.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import dynamicIconImports from 'lucide-react/dynamicIconImports';
 
 import { cn } from '@/lib/utils';

--- a/components/common/badge-with-tooltip.tsx
+++ b/components/common/badge-with-tooltip.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import {
   Tooltip,

--- a/components/common/icon.tsx
+++ b/components/common/icon.tsx
@@ -1,5 +1,4 @@
-import { memo } from 'react';
-import * as React from 'react';
+import React from 'react';
 import { LucideProps } from 'lucide-react';
 import dynamicIconImports from 'lucide-react/dynamicIconImports';
 import dynamic from 'next/dynamic';
@@ -14,4 +13,4 @@ function Icon({ name, ...props }: IconProps) {
   return <LucideIcon {...props} />;
 }
 
-export default memo(Icon);
+export default React.memo(Icon);

--- a/components/common/message-skeleton.tsx
+++ b/components/common/message-skeleton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import { Skeleton } from '../ui/skeleton';
 

--- a/components/common/message.tsx
+++ b/components/common/message.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Markdown from 'react-markdown';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';

--- a/components/dialog/_components/message-list.tsx
+++ b/components/dialog/_components/message-list.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import Message from '@/components/common/message';
 

--- a/components/dialog/chat-with-gpt-dialog.tsx
+++ b/components/dialog/chat-with-gpt-dialog.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import * as DOMPurify from 'dompurify';
-import Image from 'next/image';
 
 import { Button } from '@/components/ui/button';
 import {
@@ -12,12 +11,11 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@/components/ui/dialog';
 
-import chatGptImage from '@/assets/images/chatgpt.webp';
 import { cn } from '@/lib/utils';
 import { OpenAIMessage } from '@/services';
+import { useGPTMessageDialog } from '@/zustand/useModal';
 
 import AppTextArea from '../common/app-textarea';
 import Icon from '../common/icon';
@@ -31,9 +29,13 @@ export interface ChatWithGPTDialogProps {
   onSubmitMessage: (message: string) => void;
 }
 
-export default function ChatWithGPTDialog({
-  content, isLoading, onSubmitMessage,
-}: ChatWithGPTDialogProps) {
+export default function ChatWithGPTDialog(props: ChatWithGPTDialogProps) {
+  const {
+    content, isLoading, onSubmitMessage,
+  } = props;
+
+  console.log('dynamic nè');
+
   const [message, setMessage] = React.useState('');
 
   const contentWithoutPrompt = React.useMemo(
@@ -62,15 +64,7 @@ export default function ChatWithGPTDialog({
   };
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
-        <Button variant="outline" size="sm" onClick={(e) => e.stopPropagation()}>
-          <div className="mr-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-100">
-            <Image src={chatGptImage} alt="chat-gpt-image" />
-          </div>
-          Chat with GPT
-        </Button>
-      </DialogTrigger>
+    <Dialog open={!!content.length}>
       <DialogContent
         className="max-w-full sm:max-w-7xl"
         onInteractOutside={(e: any) => {

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import Link from 'next/link';
 
 import { Icons } from '@/components/icons';

--- a/components/progress-bar.tsx
+++ b/components/progress-bar.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { isSSR } from '@dwarvesf/react-utils';
 import { AppProgressBar as ProgressBar } from 'next-nprogress-bar';
 
 const options = { showSpinner: false };
 
-function ProgressBarProvider({ children }: PropsWithChildren) {
+function ProgressBarProvider({ children }: React.PropsWithChildren) {
   const isDarkMode = isSSR() ? 'light' : window.matchMedia('(prefers-color-scheme: dark)').matches;
   const progressBarColor = isDarkMode ? '#fff' : '#131313';
 

--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import Link from 'next/link';
 
 import { MainNav } from '@/components/main-nav';

--- a/components/tailwind-indicator.tsx
+++ b/components/tailwind-indicator.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import ENV from '@/constants/env';
+
 // eslint-disable-next-line import/prefer-default-export
 export function TailwindIndicator() {
-  if (process.env.NODE_ENV === 'production') return null;
+  if (ENV.NODE_ENV === 'production') return null;
 
   return (
     <div className="fixed bottom-1 left-1 z-50 flex h-6 w-6 items-center justify-center rounded-full bg-gray-800 p-3 font-mono text-xs text-white">

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { type ThemeProviderProps } from 'next-themes/dist/types';
 

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as React from 'react';
+import React from 'react';
 import { Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 

--- a/config/site.ts
+++ b/config/site.ts
@@ -1,18 +1,18 @@
-export type SiteConfig = typeof siteConfig
+export type SiteConfig = typeof siteConfig;
 
 export const siteConfig = {
-  name: "Cosmeller",
+  name: 'Cosmeller',
   description:
-    "A code review service for git. Automatically review your code with AI.",
+    'A code review service for git. Automatically review your code with AI.',
   mainNav: [
     {
-      title: "Home",
-      href: "/",
+      title: 'Home',
+      href: '/',
     },
   ],
   links: {
-    twitter: "https://twitter.com/shadcn",
-    github: "https://github.com/shadcn/ui",
-    docs: "https://ui.shadcn.com",
+    twitter: 'https://twitter.com/shadcn',
+    github: 'https://github.com/shadcn/ui',
+    docs: 'https://ui.shadcn.com',
   },
-}
+};

--- a/constants/env.ts
+++ b/constants/env.ts
@@ -1,0 +1,9 @@
+interface ENVType {
+  NODE_ENV: String
+}
+
+const ENV: ENVType = {
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+export default ENV;

--- a/context/auth.tsx
+++ b/context/auth.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  PropsWithChildren, useCallback, useEffect, useState,
-} from 'react';
-import * as React from 'react';
+import React from 'react';
 import { createContext, isSSR } from '@dwarvesf/react-utils';
 
 import { emitter } from '@/lib/emitter';
@@ -28,14 +25,14 @@ const cleanAuth = () => {
   window.localStorage.removeItem(userKey);
 };
 
-function AuthContextProvider({ children }: PropsWithChildren) {
-  const [isLogin, setIsLogin] = useState(() => {
+function AuthContextProvider({ children }: React.PropsWithChildren) {
+  const [isLogin, setIsLogin] = React.useState(() => {
     if (isSSR()) return false;
     return !!window.localStorage.getItem(tokenKey);
   });
-  const [user, setUser] = useState(() => (isSSR() ? '' : window.localStorage.getItem(userKey) || ''));
+  const [user, setUser] = React.useState(() => (isSSR() ? '' : window.localStorage.getItem(userKey) || ''));
 
-  const login = useCallback(async (username: string, password: string) => {
+  const login = React.useCallback(async (username: string, password: string) => {
     try {
       const res = await authApi.login({ username, password });
       if (res.data) {
@@ -49,12 +46,12 @@ function AuthContextProvider({ children }: PropsWithChildren) {
     }
   }, []);
 
-  const logout = useCallback(() => {
+  const logout = React.useCallback(() => {
     setIsLogin(false);
     cleanAuth();
   }, []);
 
-  useEffect(() => {
+  React.useEffect(() => {
     const bootstrapAsync = async () => {
       if (isLogin) {
         // Retrieve user info from local storage first

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,9 @@
+import resolveConfig from 'tailwindcss/resolveConfig';
+
+import tailwindConfig from '../tailwind.config';
+
+const tailwind = resolveConfig(tailwindConfig);
+
+export default tailwind;
+
+// https://stackoverflow.com/questions/61118060/how-to-access-tailwind-colors-from-javascript

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,5 @@
+## Hooks:
+
+| Name                   | Description                            | Returns |
+|------------------------|----------------------------------------|---------|
+| useGetGithubRepository | Get github repository                  | null    |

--- a/utils/removeDotGitURL.ts
+++ b/utils/removeDotGitURL.ts
@@ -1,0 +1,3 @@
+export default function removeDotGitURL(url: string) {
+  return url.replace(/\.git$/, '');
+}

--- a/zustand/useModal/README.md
+++ b/zustand/useModal/README.md
@@ -1,0 +1,5 @@
+## Hooks:
+
+| Name                | Description            | Returns           |
+|---------------------|------------------------|-------------------|
+| useGPTMessageDialog | For GPT Message Dialog | isOpen, setIsOpen |

--- a/zustand/useModal/index.ts
+++ b/zustand/useModal/index.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface GPTMessageDialog {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export const useGPTMessageDialog = create<GPTMessageDialog>()(
+  (set) => ({
+    isOpen: false,
+    setIsOpen: (isOpen) => set({ isOpen }),
+  }),
+);


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR includes changes that refactor the import syntax for React across multiple files. The changes are as follows:
- Replaced `import * as React from 'react'` with `import React from 'react'` in several files.
- In some cases, specific React exports like `memo` are now imported directly from 'react' along with the default import.
- Minor changes in `components/tailwind-indicator.tsx` and `config/site.ts` files.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`app/(auth)/sign-in/page.tsx`: Updated the import syntax for React.
`app/(default)/reviewing/[...slug]/_components/review-card.tsx`: Updated the import syntax for React.
`components/common/icon.tsx`: Updated the import syntax for React and imported `memo` directly from 'react'.
`components/dialog/chat-with-gpt-dialog.tsx`: Updated the import syntax for React.
`components/main-nav.tsx`: Updated the import syntax for React.
`components/tailwind-indicator.tsx`: Replaced `process.env.NODE_ENV` with `ENV.NODE_ENV`.
`components/theme-provider.tsx`: Updated the import syntax for React.
`config/site.ts`: Replaced double quotes with single quotes for string values.
`context/auth.tsx`: Updated the import syntax for React and imported specific exports directly from 'react'.
</details>
