### PR TITLE
bugfix: disable button when loading

### DIFF
--- a/components/dialog/chat-with-gpt-dialog.tsx
+++ b/components/dialog/chat-with-gpt-dialog.tsx
@@ -111,6 +111,7 @@ export default function ChatWithGPTDialog(props: ChatWithGPTDialogProps) {
                 variant="ghost"
                 size="icon"
                 className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full"
+                disabled={isLoading}
               >
                 <div className="relative">
                   <SendHorizonal


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses a bug in the chat dialog component. It disables the submit button when the chat is in a loading state, preventing multiple submissions.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`components/dialog/chat-with-gpt-dialog.tsx`: The submit button in the chat dialog has been updated to be disabled when the chat is in a loading state. This is achieved by adding a 'disabled' attribute to the button, which is set to the value of 'isLoading'.
</details>
